### PR TITLE
Control should not be touched until blur

### DIFF
--- a/packages/angular-imask/src/imask.directive.ts
+++ b/packages/angular-imask/src/imask.directive.ts
@@ -155,7 +155,6 @@ export class IMaskDirective<Opts extends IMask.AnyMaskedOptions> implements Cont
     // for details see https://github.com/uNmAnNeR/imaskjs/issues/136
     if (this._writing && value === this.endWrite()) return;
     this.onChange(value);
-    this.onTouched();
     this.accept.emit(value);
   }
 


### PR DESCRIPTION
Working with these masks and material-ui I noticed that my error messages were appearing instantly when I had set them to show only onTouched.

Please consider this fix, it's a hacky workaround to fix it.